### PR TITLE
Do not create Sitemaps for 'example.csv'

### DIFF
--- a/sitemap_generator/handler/filesystem.py
+++ b/sitemap_generator/handler/filesystem.py
@@ -66,8 +66,11 @@ class FileSystemHandler(BaseHandler):
         :returns: `None`
         """
         LOGGER.debug('Making urlsets')
-        [self.make_urlset(file)
-         for file in walk_path(self.root_path, r'.*.csv')]
+        [
+            self.make_urlset(file)
+            for file in walk_path(self.root_path, r'.*.csv')
+            if file.name != 'example.csv'
+        ]
 
         LOGGER.debug('Making sitemap index')
         urlsets = walk_path(self.root_path, r'.*.xml')


### PR DESCRIPTION
Exclude 'example.csv' from urlset generation.

# Description
<!-- Describe the purpose of this pull request -->

# Changes Made
<!-- Provide a brief overview of the changes implemented in this pull request -->

# Related Issues
<!-- If this pull request resolves any GitHub issues, reference them here -->

# Additional Notes
<!-- Any additional information or context about the pull request -->
