### PR TITLE
Remove flakey typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,12 +48,6 @@ repos:
     hooks:
       - id: addlicense
         args: ["-s=only", -l, "MIT", -c, "Lincoln Institute of Land Policy"]
-  - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.408
-    hooks:
-    - id: pyright
-      additional_dependencies:
-        - pyright[nodejs]
   - repo: local
     hooks: 
       - id: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,8 @@ repos:
     rev: v1.1.408
     hooks:
     - id: pyright
+      additional_dependencies:
+        - pyright[nodejs]
   - repo: local
     hooks: 
       - id: pytest

--- a/sitemap_generator/handler/base.py
+++ b/sitemap_generator/handler/base.py
@@ -93,9 +93,7 @@ class FileSystemHandler:
         write_tree_to_file(index, sitemap_output_dir / "sitemap.xml")
         LOGGER.info(f"Wrote sitemap index to disk at {sitemap_output_dir}/sitemap.xml")
 
-    def make_sitemap(
-        self, source: SitemapSourceWithMetadata
-    ) -> ET.ElementTree | Any:
+    def make_sitemap(self, source: SitemapSourceWithMetadata) -> ET.ElementTree | Any:
         """
         Given a source within the filesystem tree, generate a sitemap XML
         associated with that source if it is appropriate to include,

--- a/sitemap_generator/handler/base.py
+++ b/sitemap_generator/handler/base.py
@@ -30,7 +30,7 @@
 
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Any
 from xml.etree import ElementTree as ET
 
 from sitemap_generator.util import (
@@ -95,7 +95,7 @@ class FileSystemHandler:
 
     def make_sitemap(
         self, source: SitemapSourceWithMetadata
-    ) -> Optional[ET.ElementTree[ET.Element[str]]]:
+    ) -> ET.ElementTree | Any:
         """
         Given a source within the filesystem tree, generate a sitemap XML
         associated with that source if it is appropriate to include,
@@ -109,7 +109,7 @@ class FileSystemHandler:
                 return None
             case "one_to_one_csv":
                 xml_root = ET.fromstring(URLSET)
-                tree: ET.ElementTree[ET.Element[str]] = ET.ElementTree(xml_root)
+                tree = ET.ElementTree(xml_root)
 
                 for mapper in csv_to_sitemap_url_list(source.path):
                     url_element = ET.fromstring(

--- a/sitemap_generator/util.py
+++ b/sitemap_generator/util.py
@@ -30,7 +30,7 @@
 
 from dataclasses import dataclass
 import datetime
-from typing import Generator, Literal, NamedTuple
+from typing import Generator, Literal, NamedTuple, Any
 
 import click
 import csv
@@ -63,7 +63,7 @@ def csv_to_sitemap_url_list(csv_path: Path) -> Generator[UrlToGeoconnexPid, None
             )
 
 
-def write_tree_to_file(tree: ET.ElementTree | ET.ElementTree[ET.Element], file: Path):
+def write_tree_to_file(tree: ET.ElementTree | Any, file: Path):
     ET.register_namespace("", "http://www.sitemaps.org/schemas/sitemap/0.9")
     ET.register_namespace("geoconnex", "https://geoconnex.us")
     tree.write(file_or_filename=file, encoding="utf-8", xml_declaration=True)


### PR DESCRIPTION
# Description
Revert use of ET.ElementTree as a generic class given that it is not stable across python version

# Changes Made
<!-- Provide a brief overview of the changes implemented in this pull request -->

# Related Issues
<!-- If this pull request resolves any GitHub issues, reference them here -->

# Additional Notes
<!-- Any additional information or context about the pull request -->
