### PR TITLE
Cleaner parent / child naming for urn

### DIFF
--- a/sitemap_generator/util.py
+++ b/sitemap_generator/util.py
@@ -89,13 +89,15 @@ class SitemapSourceWithMetadata:
     metadata: dict
 
     def canonical_sitemap_name(self, root_relative_dir: Path) -> str:
-        relative_path = self.path.relative_to(root_relative_dir)
-        return (
-            str(relative_path)
-            .replace("-", "_")
-            .removesuffix(".csv")
-            .removesuffix(".xml")
+        cleaned_path = (
+            self.path.relative_to(root_relative_dir)
+            .with_suffix("")  # remove suffix
         )
+
+        if cleaned_path.name == cleaned_path.parent.name:
+            cleaned_path = cleaned_path.parent
+
+        return cleaned_path.as_posix().replace("-", "_")
 
     def source_to_xml_for_index(self, base_uri: str, root_dir: Path) -> ET.Element:
         SITEMAP_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"

--- a/sitemap_generator/util.py
+++ b/sitemap_generator/util.py
@@ -90,8 +90,7 @@ class SitemapSourceWithMetadata:
 
     def canonical_sitemap_name(self, root_relative_dir: Path) -> str:
         cleaned_path = (
-            self.path.relative_to(root_relative_dir)
-            .with_suffix("")  # remove suffix
+            self.path.relative_to(root_relative_dir).with_suffix("")  # remove suffix
         )
 
         if cleaned_path.name == cleaned_path.parent.name:


### PR DESCRIPTION
Update cannonical sitemap name logic to reduce identical parent / child filenames into one URN (i.e. /ref/hu08/hu08.csv -> /ref/hu08)

# Description
<!-- Describe the purpose of this pull request -->

# Changes Made
<!-- Provide a brief overview of the changes implemented in this pull request -->

# Related Issues
<!-- If this pull request resolves any GitHub issues, reference them here -->

# Additional Notes
<!-- Any additional information or context about the pull request -->
