### PR TITLE
Support custom base uris for sitemaps in the github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,18 +40,10 @@ inputs:
     description: "Filepath to load data from"
     required: true
     default: "./namespaces"
-  sitemap_dir:
-    description: "Directory for sitemap output"
+  base_uri:
+    description: "Base URI for sitemap"
     required: true
-    default: "./sitemap"
-  source_repo:
-    description: "Source repository"
-    required: true
-    default: "geoconnex.us"
-  source_repo_path:
-    description: "Filepath to git lastmod from"
-    required: true
-    default: "namespaces"
+    default: "https://geoconnex.us"
 outputs:
   sitemap:
     description: "Sitemap folder"
@@ -63,7 +55,7 @@ runs:
         SITEMAP_DIR: ${{ inputs.sitemap_dir }}
       run: |
         pip3 install git+https://github.com/cgs-earth/sitemap-generator.git
-        sitemap-generator run ${{ inputs.namespace_dir }}
+        sitemap-generator run ${{ inputs.namespace_dir }} --uri-base ${{ inputs.base_uri }}
 
     - name: Zip sitemap
       uses: vimtor/action-zip@v1

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: "Filepath to load data from"
     required: true
     default: "./namespaces"
+  sitemap_dir:
+    description: "Directory for sitemap output"
+    required: true
+    default: "./sitemap"
   base_uri:
     description: "Base URI for sitemap"
     required: true


### PR DESCRIPTION
- Get rid of inputs to the github action that are not used at all
- Allow specifying base_uri for the purposes of allowing sitemaps that point to to pids.geoconnex.dev instead of the production geoconnex.us site