### PR TITLE
Remove `bulk:` from sitemap ids and lastMod from bulk sitemaps

### DIFF
--- a/sitemap_generator/handler/base.py
+++ b/sitemap_generator/handler/base.py
@@ -64,8 +64,6 @@ BULK_SITEMAP_TEMPLATE = """<?xml version='1.0' encoding='utf-8'?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:ns1="http://geoconnex.us/schemas/sitemap">
     <url>
         <loc>{}</loc>
-        <lastmod>{}</lastmod>
-        <ns1:type>bulk</ns1:type>
     </url>
 </urlset>"""
 

--- a/sitemap_generator/util.py
+++ b/sitemap_generator/util.py
@@ -129,7 +129,10 @@ class SitemapSourceWithMetadata:
 
         # sitemap_id
         sitemap_id = ET.SubElement(sitemap_el, f"{{{GEOCONNEX_NS}}}sitemap_id")
-        sitemap_id.text = sitemap_location.replace("/", ":")
+        # Convert the path to a URL/S3-safe URN string.
+        # If the sitemap was in the bulk directory, we remove the bulk prefix given the fact it is an
+        # implementation detail, not a part of the original data
+        sitemap_id.text = sitemap_location.replace("/", ":").removeprefix("bulk:")
 
         # metadata fields (safe escaping handled automatically)
         for key, value in self.metadata.items():

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -158,8 +158,6 @@ def test_sitemap_bulk_handler(handler: FileSystemHandler):
                 xmlns:ns1="http://geoconnex.us/schemas/sitemap">
             <url>
                 <loc>internetofwater/gnis_bulk_rdf:latest</loc>
-                <lastmod>2025-02-05T16:39:34Z</lastmod>
-                <ns1:type>bulk</ns1:type>
             </url>
         </urlset>
         """


### PR DESCRIPTION
- Remove `bulk:` from sitemap_ids since bulk is essentially an internal implementation detail about harvesting, not something that we need to expose as an inherent property of the dataset.
- Remove lastMod from the bulk sitemap.xml. Metadata about lastMod is still stored in the sitemap index. This just makes it consistent with the other sitemaps for individual features.